### PR TITLE
trocados arrays para listas no calculo da pressão

### DIFF
--- a/2emissores.py
+++ b/2emissores.py
@@ -2,16 +2,17 @@ import matplotlib.pyplot as plt
 import numpy as np
 import levitacao
 
-SO = levitacao.SimuladorOndas(uL='m', uM='kg', uT='s') 
+SO = levitacao.SimuladorOndas(uL='m', uM='kg', uT='s', nome="teste") 
 
 zm = 1e-3*np.linspace(1,20, 200)
 coord=[]
 for zi in zm:
     coord.append(np.array([0,0,zi]))
 
-SO.criaEmissor(7e-3, .5e-3, [0,0,1], [0,0,-1e-3], 1)
-SO.criaRefletor(7e-3, .5e-3, [0,0,-1], [0,0,21e-3])
-#SO.criaEmissor(7e-3, 1e-3, [0,0,-1], [0,0,21e-3], 1, fase = math.pi)
+SO.criaEmissor(7e-3, 1e-3, [0,0,1], [0,0,-1e-3], 1)
+#SO.criaRefletor(7e-3, 1e-3, [0,0,-1], [0,0,21e-3])
+#SO.criaBola(1e-3, 50, [0,0,21e-3])
+SO.criaEmissor(7e-3, 1e-3, [0,0,-1], [0,0,21e-3], 1, fase = np.pi)
 
 P = SO.calculaP(coord, 4)
 

--- a/levitacao.py
+++ b/levitacao.py
@@ -107,21 +107,23 @@ class SimuladorOndas:
            P = np.add(P, em.pressao(Pts))     
         Ptotal.append(P)
         if(Nref != 0):
-            A = []
+            A = [] #aqui é importante trabalhar com listas e não com arrays pq cada elemento possui um número diferente de pontos, o que torna a lista não homogênea
             for ref in refEff:
                A.append(ref.superficie()) 
-            A = np.array(A)
+            
             #T-->R
-            P = np.zeros([np.shape(A)[0],np.shape(A)[1]])
-            for T, i in zip(self.emissores, range(0, len(self.emissores))):
-                PT =[]
-                for Ai, j in zip(A, range(0,len(A))):
+            P=[]
+            for Ai, j in zip(A, range(0,len(A))):
+                Pa = [0] * len(Ai)
+                for T, i in zip(self.emissores, range(0, len(self.emissores))):   
                     if(j!=i):
-                        PT.append(T.pressao(Ai))
-                    else:
-                        PT.append(np.zeros(np.shape(Ai)[0]))
-                P = np.add(P, PT)
+                        PAi = T.pressao(Ai)
+                        Pa = [Pa[f] + PAi[f] for f in range(len(Pa))]
+                P = P+[Pa]   
+            
             Pint = P #guarda o valor da pressão intermediária na superficie dos refletores
+            
+            #---------------------
             
             #R-->M
             P = np.zeros(len(Pts))
@@ -131,15 +133,16 @@ class SimuladorOndas:
             
             for N in range (0,Nref-1):
                 #R-->R
-                P = np.zeros([np.shape(A)[0],np.shape(A)[1]])
-                for R, Pinc, i in zip(refEff,Pint, range(0, len(refEff))):
-                    PT =[]
-                    for Ai, j in zip(A, range(0,len(A))):
+                
+                P=[]
+                for Ai, j in zip(A, range(0,len(A))):
+                    Pa = [0] * len(Ai)
+                    for R, Pinc, i in zip(refEff,Pint, range(0, len(refEff))):  
                         if(j!=i):
-                            PT.append(R.pressao(Ai, Pinc))
-                        else:
-                            PT.append(np.zeros(np.shape(Ai)[0]))
-                    P = np.add(P, PT)
+                            PAi = R.pressao(Ai, Pinc)
+                            Pa = [Pa[f] + PAi[f] for f in range(len(Pa))]
+                    P = P+[Pa]   
+                
                 Pint = P #guarda o valor da pressão intermediária na superficie dos refletores
                 
                 #R-->M


### PR DESCRIPTION
Isso foi feito para possibilitar a não homogeneidade das listas, assim possibilitando que o código trabalhe com elementos de diferentes tamanhos.

Foi então invertida a ordem dos loops duplos para facilitar na composição das listas de pressão